### PR TITLE
Update health check endpoint to fail on invalid access token

### DIFF
--- a/seclytics-augur-pxdr/operations.py
+++ b/seclytics-augur-pxdr/operations.py
@@ -72,9 +72,10 @@ def download_predictions(config, params):
 
 def check_api_health(config):
     """Check Seclytics api access."""
-    auth_endpoint = '/status'
-    # Raises an exception on unsuccessful responses
-    Seclytics(config).api_get(auth_endpoint)
-
-    # No exceptions, we're good!
+    auth_endpoint = '/files/77770000022222211333333444445555'
+    try:
+        # Raises an exception on unsuccessful responses
+        Seclytics(config).api_get(auth_endpoint)
+    except:
+        return False
     return True


### PR DESCRIPTION
Use a different api endpoint to fail on invalid access token input.